### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ Proxy SwitchyOmega设置教程：[Chrome](Other/7-2-chrome-setup-guide-cn.md)  |
 
 ## Star 历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=selierlin/Share-SSR-V2ray&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=selierlin/Share-SSR-V2ray&type=Date)


### PR DESCRIPTION
Run: the current star history chart in README.md is broken and no longer displays due to GitHub stargazer API restrictions. This PR points it at the working star-history.dera.page service so the chart renders correctly again.